### PR TITLE
Remove <br> that sneaks into package website

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ So instead of searching Stack Overflow for "email regex" we could have a well-te
 And as the community handles more and more cases in an _excellent_ way, I hope a day will come when no one wants the `regex` package anymore.
 
 
-<br>
-
 
 ## Historical Notes
 


### PR DESCRIPTION
A stray `<br>` appears in the package website docs. This PR deletes it.

<img width="625" alt="screen shot 2018-06-05 at 6 11 32 am" src="https://user-images.githubusercontent.com/1094080/40978027-69bec6b4-6887-11e8-9202-50d519afc132.png">
