### PR TITLE
Add Regex.escape

### DIFF
--- a/src/Elm/Kernel/Regex.js
+++ b/src/Elm/Kernel/Regex.js
@@ -26,6 +26,11 @@ var _Regex_fromStringWith = F2(function(options, string)
 	}
 });
 
+var _Regex_escape = F1(function(string)
+{
+	return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+});
+
 
 // USE
 

--- a/src/Regex.elm
+++ b/src/Regex.elm
@@ -3,6 +3,7 @@ module Regex exposing
   , fromString
   , fromStringWith
   , Options
+  , escape
   , never
   , contains
   , split
@@ -89,6 +90,13 @@ type alias Options =
   { caseInsensitive : Bool
   , multiline : Bool
   }
+
+
+{-| Escape strings to be regular expressions, making all special characters safe.
+-}
+escape : String -> String
+escape =
+  Elm.Kernel.Regex.escape
 
 
 {-| A regular expression that never matches any string.


### PR DESCRIPTION
This function was present in `Regex` in 0.18 and it would be very useful to have it available in this iteration of the API as well.