### PR TITLE
Support the unicode flag

### DIFF
--- a/src/Elm/Kernel/Regex.js
+++ b/src/Elm/Kernel/Regex.js
@@ -15,6 +15,7 @@ var _Regex_fromStringWith = F2(function(options, string)
 	var flags = 'g';
 	if (options.__$multiline) { flags += 'm'; }
 	if (options.__$caseInsensitive) { flags += 'i'; }
+    if (options.__$unicode) { flags += 'u'; }
 
 	try
 	{

--- a/src/Regex.elm
+++ b/src/Regex.elm
@@ -66,7 +66,7 @@ they would look like `"\\w\\s\\d"`.
 -}
 fromString : String -> Maybe Regex
 fromString string =
-  fromStringWith { caseInsensitive = False, multiline = False } string
+  fromStringWith { caseInsensitive = False, multiline = False, unicode = False } string
 
 
 {-| Create a `Regex` with some additional options. For example, you can define
@@ -76,7 +76,7 @@ fromString string =
 
     fromString : String -> Maybe Regex.Regex
     fromString string =
-      fromStringWith { caseInsensitive = False, multiline = False } string
+      fromStringWith { caseInsensitive = False, multiline = False, unicode = False } string
 
 -}
 fromStringWith : Options -> String -> Maybe Regex
@@ -88,6 +88,7 @@ fromStringWith =
 type alias Options =
   { caseInsensitive : Bool
   , multiline : Bool
+  , unicode : Bool
   }
 
 


### PR DESCRIPTION
Fixes issue https://github.com/elm/regex/issues/14

This PR adds an additional option called `unicode` which includes the `u` unicode flag.  This would have been very convenient for recent work as I needed code able to match any letter - where letters might include foreign author names and book titles.  Being able to access the "\p{Letter}" unicode character class would have been the ideal solution.  However that requires the unicode switch to be set. 